### PR TITLE
Testing

### DIFF
--- a/backend/startup/config.js
+++ b/backend/startup/config.js
@@ -5,13 +5,13 @@ if (!config.get('jwtPrivateKey'))
   throw new Error('FATAL ERROR: vidly_jwtPrivateKey is not defined.');
 
 const host = os.type() === 'Windows_NT' ? os.hostname() : 'localhost';
-const dbStringBase = `mongodb://${host}:27017,${host}:27018,${host}:27019/vidly`;
+const dbString = `mongodb://${host}:27017,${host}:27018,${host}:27019?replicaSet=rs`;
 const env = process.env.NODE_ENV || 'development';
 
 module.exports = {
-  dbString: `${dbStringBase}_${env}`,
+  dbString,
   dbOptions: {
-    replicaSet: 'rs',
+    dbName: `vidly_${env}`,
     useNewUrlParser: true,
     useUnifiedTopology: true,
     useFindAndModify: false,

--- a/backend/startup/logging.js
+++ b/backend/startup/logging.js
@@ -36,7 +36,7 @@ winston.exceptions.handle(
   }),
   new winston.transports.MongoDB({
     db: dbString,
-    options: { replicaSet: 'rs', useUnifiedTopology: true }
+    options: { useUnifiedTopology: true }
   })
 );
 
@@ -68,7 +68,7 @@ winston.loggers.add('db', {
   transports: [
     new winston.transports.MongoDB({
       db: dbString,
-      options: { replicaSet: 'rs', useUnifiedTopology: true }
+      options: { useUnifiedTopology: true }
     })
   ]
 });

--- a/backend/tests/testHelper.js
+++ b/backend/tests/testHelper.js
@@ -18,7 +18,10 @@ module.exports.setup = function setup(routeName, appToTest) {
   app = appToTest;
 
   beforeAll(async () => {
-    await mongoose.connect(`${dbString}_routes_${route}`, dbOptions);
+    await mongoose.connect(dbString, {
+      ...dbOptions,
+      dbName: `${dbOptions.dbName}_routes_${route}`
+    });
     winston.loggers.get = jest.fn().mockReturnValue({ error: jest.fn() });
     winston.error = jest.fn();
   });

--- a/backend/tests/unit/middleware/find.test.js
+++ b/backend/tests/unit/middleware/find.test.js
@@ -1,40 +1,61 @@
-const mongoose = require('mongoose');
-const { dbString, dbOptions } = require('../../../startup/config');
 const find = require('../../../middleware/find');
 
 describe('find middleware', () => {
+  const modelName = 'Document';
+  const doc = { _id: 1 };
   let Model;
-  let doc;
+  let lean;
   let req;
   let res;
+  let send;
   let next;
 
-  beforeAll(async () => {
-    Model = mongoose.model('Model', new mongoose.Schema({ name: String }));
-    await mongoose.connect(`${dbString}_middleware_find`, dbOptions);
-  });
-
   beforeEach(async () => {
-    doc = await new Model({ name: 'Model Name' }).save();
+    lean = jest.fn();
+    Model = {
+      inspect() {
+        return `Model { ${modelName} }`;
+      },
+      findById: jest.fn((id) => {
+        if (id === doc._id) return { doc, lean };
+        return undefined;
+      })
+    };
     req = { params: { id: doc._id } };
-    res = { status: jest.fn().mockReturnValue({ send: jest.fn() }) };
+    send = jest.fn();
+    res = { status: jest.fn().mockReturnValue({ send }) };
     next = jest.fn();
   });
 
-  afterEach(async () => {
-    await Model.deleteMany();
+  it('should fetch a document with the given id', async () => {
+    await find(Model)(req, res, next);
+
+    expect(Model.findById).toHaveBeenCalled();
   });
 
-  afterAll(async () => {
-    await mongoose.disconnect();
+  it('should fetch a lean document if lean parameter is truthy', async () => {
+    await find(Model, true)(req, res, next);
+
+    expect(Model.findById).toHaveBeenCalled();
+    expect(lean).toHaveBeenCalled();
   });
 
   it('should set status to 404 if id is not found', async () => {
-    req.params.id = mongoose.Types.ObjectId();
+    req.params.id = 2;
 
     await find(Model)(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('should send a message with modelName if id is not found', async () => {
+    req.params.id = 2;
+
+    await find(Model)(req, res, next);
+
+    expect(send.mock.calls[0][0]).toMatch(
+      new RegExp(`${modelName}.*not.*found`)
+    );
   });
 
   it('should populate req.doc with the requested document', async () => {

--- a/backend/tests/unit/middleware/put.test.js
+++ b/backend/tests/unit/middleware/put.test.js
@@ -1,49 +1,31 @@
-const mongoose = require('mongoose');
-const { dbString, dbOptions } = require('../../../startup/config');
 const put = require('../../../middleware/put');
 
 describe('put middleware', () => {
-  let Model;
   let doc;
   let req;
   let res;
   let next;
 
-  beforeAll(async () => {
-    Model = mongoose.model('Model', new mongoose.Schema({ name: String }));
-    await mongoose.connect(`${dbString}_middleware_put`, dbOptions);
-  });
-
   beforeEach(async () => {
-    doc = await new Model({ name: 'Model Name' }).save();
-    req = { body: { name: 'Updated Model Name' }, doc };
+    doc = { set: jest.fn(), save: jest.fn() };
+    req = { body: {}, doc };
     res = { status: jest.fn().mockReturnValue({ send: jest.fn() }) };
     next = jest.fn();
   });
 
-  afterEach(async () => {
-    await Model.deleteMany();
-  });
-
-  afterAll(async () => {
-    await mongoose.disconnect();
-  });
-
-  it('should populate req.doc with the updated document', async () => {
+  it('should set req.doc with the requested update values', async () => {
     await put(req, res, next);
 
-    expect(req.doc).toMatchObject(req.body);
+    expect(req.doc.set).toHaveBeenCalledWith(req.body);
   });
 
   it('should save the document to the database', async () => {
     await put(req, res, next);
 
-    const docInDB = await Model.findOne(req.body);
-
-    expect(docInDB).toMatchObject(req.body);
+    expect(req.doc.save).toHaveBeenCalled();
   });
 
-  it('should call next if document is found', async () => {
+  it('should call next after the document is saved', async () => {
     await put(req, res, next);
 
     expect(next).toHaveBeenCalled();

--- a/backend/tests/unit/middleware/remove.test.js
+++ b/backend/tests/unit/middleware/remove.test.js
@@ -1,54 +1,59 @@
-const mongoose = require('mongoose');
-const { dbString, dbOptions } = require('../../../startup/config');
 const remove = require('../../../middleware/remove');
 
 describe('remove middleware', () => {
+  const modelName = 'Document';
+  const doc = { _id: 1 };
   let Model;
-  let doc;
+  let lean;
   let req;
   let res;
+  let send;
   let next;
 
-  beforeAll(async () => {
-    Model = mongoose.model('Model', new mongoose.Schema({ name: String }));
-    await mongoose.connect(`${dbString}_middleware_remove`, dbOptions);
-  });
-
   beforeEach(async () => {
-    doc = await new Model({ name: 'Model Name' }).save();
+    lean = jest.fn().mockReturnValue(doc);
+    Model = {
+      inspect() {
+        return `Model { ${modelName} }`;
+      },
+      findByIdAndDelete: jest.fn((id) => {
+        if (id === doc._id) return { lean };
+        return { lean: jest.fn() };
+      })
+    };
     req = { params: { id: doc._id } };
-    res = { status: jest.fn().mockReturnValue({ send: jest.fn() }) };
+    send = jest.fn();
+    res = { status: jest.fn().mockReturnValue({ send }) };
     next = jest.fn();
   });
 
-  afterEach(async () => {
-    await Model.deleteMany();
-  });
+  it('should delete the document from the database', async () => {
+    await remove(Model)(req, res, next);
 
-  afterAll(async () => {
-    await mongoose.disconnect();
+    expect(Model.findByIdAndDelete).toHaveBeenCalled();
+    expect(lean).toHaveBeenCalled();
   });
 
   it('should set status to 404 if id is not found', async () => {
-    req.params.id = mongoose.Types.ObjectId();
+    req.params.id = 2;
 
     await remove(Model)(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(404);
+    expect(send.mock.calls[0][0]).toMatch(new RegExp(modelName));
+  });
+
+  it('should set a message with modelName if id is not found', async () => {
+    req.params.id = 2;
+
+    await remove(Model)(req, res, next);
+
+    expect(send.mock.calls[0][0]).toMatch(new RegExp(modelName));
   });
 
   it('should populate req.doc with the deleted document', async () => {
     await remove(Model)(req, res, next);
 
     expect(req).toHaveProperty('doc');
-  });
-
-  it('should delete the document from the database', async () => {
-    await remove(Model)(req, res, next);
-
-    const docInDB = await Model.findById(doc._id);
-
-    expect(docInDB).toBeNull();
   });
 
   it('should call next if document is found', async () => {

--- a/backend/tests/unit/startup/config.test.js
+++ b/backend/tests/unit/startup/config.test.js
@@ -25,7 +25,7 @@ describe('config startup', () => {
     }).not.toThrow();
   });
 
-  it('should use localhost for db string if os type is not Windows', () => {
+  it('should use localhost for dbString if os type is not Windows', () => {
     const os = require('os');
     os.type = jest.fn().mockReturnValue('Linux');
 
@@ -34,7 +34,7 @@ describe('config startup', () => {
     expect(dbString).toMatch(/localhost/);
   });
 
-  it('should use hostname for db string if os type is Windows', () => {
+  it('should use hostname for dbString if os type is Windows', () => {
     const os = require('os');
     os.type = jest.fn().mockReturnValue('Windows_NT');
 
@@ -43,17 +43,17 @@ describe('config startup', () => {
     expect(dbString).toMatch(new RegExp(os.hostname()));
   });
 
-  it('should add development to db string if NODE_ENV is undefined', () => {
+  it('should add "development" to dbName if NODE_ENV is undefined', () => {
     delete process.env.NODE_ENV;
 
-    const { dbString } = require('../../../startup/config');
+    const { dbOptions } = require('../../../startup/config');
 
-    expect(dbString).toMatch(/development/);
+    expect(dbOptions.dbName).toMatch(/development/);
   });
 
-  it('should add NODE_ENV to db string if it is defined', () => {
-    const { dbString } = require('../../../startup/config');
+  it('should add NODE_ENV to dbName if it is defined', () => {
+    const { dbOptions } = require('../../../startup/config');
 
-    expect(dbString).toMatch(/test/);
+    expect(dbOptions.dbName).toMatch(/test/);
   });
 });

--- a/backend/tests/unit/startup/db.test.js
+++ b/backend/tests/unit/startup/db.test.js
@@ -1,21 +1,18 @@
 const mongoose = require('mongoose');
 const winston = require('winston');
-const { dbString } = require('../../../startup/config');
+const { dbString, dbOptions } = require('../../../startup/config');
 const connectToDB = require('../../../startup/db');
 
 describe('db startup', () => {
   beforeEach(() => {
+    mongoose.connect = jest.fn();
     winston.info = jest.fn();
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
   });
 
   it('should connect to vidly_test mongodb', async () => {
     await connectToDB();
 
-    expect(mongoose.connection.db.databaseName).toMatch(/vidly_test/);
+    expect(mongoose.connect).toHaveBeenCalledWith(dbString, dbOptions);
   });
 
   it('should log the connection status to winston', async () => {

--- a/backend/tests/unit/startup/logging.test.js
+++ b/backend/tests/unit/startup/logging.test.js
@@ -123,12 +123,12 @@ describe('logging startup', () => {
         );
         expect(winston.transports.MongoDB).toHaveBeenCalledTimes(2);
         expect(winston.transports.MongoDB.mock.calls[0][0]).toMatchObject({
-          db: `${dbString.slice(0, -4)}development`,
-          options: { replicaSet: 'rs', useUnifiedTopology: true }
+          db: dbString,
+          options: { useUnifiedTopology: true }
         });
         expect(winston.transports.MongoDB.mock.calls[1][0]).toMatchObject({
-          db: `${dbString.slice(0, -4)}development`,
-          options: { replicaSet: 'rs', useUnifiedTopology: true }
+          db: dbString,
+          options: { useUnifiedTopology: true }
         });
         expect(process.on).toHaveBeenCalledWith(
           'unhandledRejection',
@@ -164,12 +164,12 @@ describe('logging startup', () => {
         );
         expect(winston.transports.MongoDB).toHaveBeenCalledTimes(2);
         expect(winston.transports.MongoDB.mock.calls[0][0]).toMatchObject({
-          db: `${dbString.slice(0, -4)}production`,
-          options: { replicaSet: 'rs', useUnifiedTopology: true }
+          db: dbString,
+          options: { useUnifiedTopology: true }
         });
         expect(winston.transports.MongoDB.mock.calls[1][0]).toMatchObject({
-          db: `${dbString.slice(0, -4)}production`,
-          options: { replicaSet: 'rs', useUnifiedTopology: true }
+          db: dbString,
+          options: { useUnifiedTopology: true }
         });
         expect(process.on).toHaveBeenCalledWith(
           'unhandledRejection',


### PR DESCRIPTION
Some tests were failing or succeeding inconsistently when all tests were run. It seems the issue was too many db connections being used concurrently in jest tests. Current solution is reducing the number of database connections by mocking calls in middleware and models tests.  A more scalable solution could be using something like `-- maxWorkers 4` or `--runInBand` when running tests,  but connecting to mongodb only in integration tests seems to work for now.